### PR TITLE
Use <sys/sysmacros.h> instead of <linux/kdev_t.h>.

### DIFF
--- a/src/drpm_block.c
+++ b/src/drpm_block.c
@@ -22,6 +22,8 @@
 #include "drpm.h"
 #include "drpm_private.h"
 
+#include <sys/sysmacros.h>
+
 #include <stdint.h>
 #include <stdbool.h>
 #include <unistd.h>
@@ -31,7 +33,6 @@
 #include <sys/stat.h>
 #include <sys/wait.h>
 #include <fcntl.h>
-#include <linux/kdev_t.h>
 
 #define MAX_OPEN_FILES 50
 #define MAX_CORE_BLOCKS 5000
@@ -546,8 +547,8 @@ void fill_cpio_header(struct blocks *blks, ssize_t index)
     }
 
     if (S_ISBLK(file.mode) || S_ISCHR(file.mode)) {
-        header.rdevmajor = MAJOR(file.rdev);
-        header.rdevminor = MINOR(file.rdev);
+        header.rdevmajor = major(file.rdev);
+        header.rdevminor = minor(file.rdev);
     }
 
     header.nlink = 1;

--- a/src/drpm_make.c
+++ b/src/drpm_make.c
@@ -22,6 +22,8 @@
 #include "drpm.h"
 #include "drpm_private.h"
 
+#include <sys/sysmacros.h>
+
 #include <stdio.h>
 #include <stdint.h>
 #include <stdbool.h>
@@ -34,7 +36,6 @@
 #include <openssl/sha.h>
 #include <rpm/rpmfi.h>
 #include <rpm/rpmfc.h>
-#include <linux/kdev_t.h>
 
 #define BUFFER_SIZE 4096
 
@@ -414,8 +415,8 @@ int parse_cpio_from_rpm_filedata(struct rpm *rpm_file,
             } else if (S_ISLNK(file.mode)) {
                 cpio_hdr.filesize = strlen(file.linkto);
             } else if (S_ISBLK(file.mode) || S_ISCHR(file.mode)) {
-                cpio_hdr.rdevmajor = MAJOR(file.rdev);
-                cpio_hdr.rdevminor = MINOR(file.rdev);
+                cpio_hdr.rdevmajor = major(file.rdev);
+                cpio_hdr.rdevminor = minor(file.rdev);
             }
         }
 
@@ -483,8 +484,8 @@ int parse_cpio_from_rpm_filedata(struct rpm *rpm_file,
             if (MD5_Update(&seq_md5, name, name_len) != 1 ||
                 md5_update_be32(&seq_md5, cpio_hdr.mode) != 1 ||
                 md5_update_be32(&seq_md5, cpio_hdr.filesize) != 1 ||
-                md5_update_be32(&seq_md5, MKDEV(cpio_hdr.rdevmajor,
-                                                cpio_hdr.rdevminor)) != 1) {
+                md5_update_be32(&seq_md5, makedev(cpio_hdr.rdevmajor,
+                                                  cpio_hdr.rdevminor)) != 1) {
                 error = DRPM_ERR_OTHER;
                 goto cleanup_fail;
             }


### PR DESCRIPTION
Hi,

Thanks for maintaining libdrpm!

What do you think about the attached patch that fixes the build on the GNU Hurd by using a glibc header file instead of a Linux-specific one to get the macros related to the major/minor device ID numbers?

G'luck,
Peter
