### PR TITLE
Fix SIGSEGV when an errors occurs in `rpm_get_file_info` (RhBug:1968594)

### DIFF
--- a/src/drpm_make.c
+++ b/src/drpm_make.c
@@ -332,8 +332,10 @@ int parse_cpio_from_rpm_filedata(struct rpm *rpm_file,
     if (MD5_Init(&seq_md5) != 1)
         return DRPM_ERR_OTHER;
 
-    if ((error = rpm_get_file_info(rpm_file, &files, &file_count, &file_colors)) != DRPM_ERR_OK ||
-        (error = rpm_get_digest_algo(rpm_file, &digest_algo)) != DRPM_ERR_OK)
+    if ((error = rpm_get_file_info(rpm_file, &files, &file_count, &file_colors)) != DRPM_ERR_OK)
+        return error;
+
+    if ((error = rpm_get_digest_algo(rpm_file, &digest_algo)) != DRPM_ERR_OK)
         goto cleanup_fail;
 
     rpm_archive_rewind(rpm_file);


### PR DESCRIPTION
`rpm_get_file_info` already cleans up `files` array in its error
handling, doing it again in the caller (`parse_cpio_from_rpm_filedata`)
results in a crash

Since we are at the begging of the `parse_cpio_from_rpm_filedata` and
there is nothing to clean up yet there is no need to `goto` to the error
handling, we can return directly.

https://bugzilla.redhat.com/show_bug.cgi?id=1968594