### PR TITLE
For rpms without any files return file count 0 (RhBug:1968594)

### DIFF
--- a/src/drpm_rpm.c
+++ b/src/drpm_rpm.c
@@ -769,6 +769,7 @@ int rpm_get_file_info(struct rpm *rpmst, struct file_info **files_ret,
         headerGet(rpmst->header, RPMTAG_FILEMODES, filemodes, HEADERGET_MINMEM) != 1 ||
         headerGet(rpmst->header, RPMTAG_FILEVERIFYFLAGS, fileverify, HEADERGET_MINMEM) != 1 ||
         headerGet(rpmst->header, RPMTAG_FILELINKTOS, filelinktos, HEADERGET_MINMEM) != 1) {
+        count_ret = 0;
         goto cleanup;
     }
 


### PR DESCRIPTION
When the processed rpm file doesn't have any files `rpm_get_file_info`
doesn't consider it an error therefore it should set `count_ret` to 0.

Otherwise it can lead to crashes when the caller of `rpm_get_file_info`
doesn't zero initialize the count variable. Such as in:
`parse_cpio_from_rpm_filedata`

https://bugzilla.redhat.com/show_bug.cgi?id=1968594