### PR TITLE
Fix: set the actual value, not the pointer. (RhBug:1968594)

### DIFF
--- a/src/drpm_rpm.c
+++ b/src/drpm_rpm.c
@@ -769,7 +769,7 @@ int rpm_get_file_info(struct rpm *rpmst, struct file_info **files_ret,
         headerGet(rpmst->header, RPMTAG_FILEMODES, filemodes, HEADERGET_MINMEM) != 1 ||
         headerGet(rpmst->header, RPMTAG_FILEVERIFYFLAGS, fileverify, HEADERGET_MINMEM) != 1 ||
         headerGet(rpmst->header, RPMTAG_FILELINKTOS, filelinktos, HEADERGET_MINMEM) != 1) {
-        count_ret = 0;
+        *count_ret = 0;
         goto cleanup;
     }
 


### PR DESCRIPTION
This fixes the previous commit, all the reasoning still applies.

I didn't notice this before because the crash goes away even without the fix if I do the build manually. I think this is due to some `gcc` settings where it enforces zero initialization in my local build but not in the rpm builds. 
Also interestingly I can only reproduce this on Fedoras < 33, for F34 it doesn't crash and the `count_ret` is automatically initialized to 0.

Regardless the proper fix is to set the value of `count_ret` not the pointer.

https://bugzilla.redhat.com/show_bug.cgi?id=1968594