### PR TITLE
Use the OpenSSL EVP_Digest*() functions

### DIFF
--- a/src/drpm_decompstrm.c
+++ b/src/drpm_decompstrm.c
@@ -37,7 +37,7 @@
 #ifdef WITH_ZSTD
 #include <zstd.h>
 #endif
-#include <openssl/md5.h>
+#include <openssl/evp.h>
 
 /* magic bytes for determining compression type */
 #define MAGIC_BZIP2(x) (((x) >> 40) == 0x425A68)
@@ -67,7 +67,7 @@ struct decompstrm {
     int (*read_chunk)(struct decompstrm *);
     void (*finish)(struct decompstrm *);
     size_t comp_size;
-    MD5_CTX *md5;
+    EVP_MD_CTX *md5;
     const unsigned char *buffer;
     size_t buffer_len;
 };
@@ -261,7 +261,7 @@ int decompstrm_destroy(struct decompstrm **strm)
  * If <md5> is not NULL, input data will be used to update the MD5 context.
  * If <filedesc> is valid, compressed data will be read from the file.
  * Otherwise, input data is read from <buffer> of size <buffer_len>. */
-int decompstrm_init(struct decompstrm **strm, int filedesc, unsigned short *comp, MD5_CTX *md5,
+int decompstrm_init(struct decompstrm **strm, int filedesc, unsigned short *comp, EVP_MD_CTX *md5,
                     const unsigned char *buffer, size_t buffer_len)
 {
     uint64_t magic;
@@ -478,7 +478,7 @@ int readchunk(struct decompstrm *strm)
 
     strm->comp_size = strm->data_len;
 
-    if (strm->md5 != NULL && MD5_Update(strm->md5, buffer, in_len) != 1)
+    if (strm->md5 != NULL && EVP_DigestUpdate(strm->md5, buffer, in_len) != 1)
         return DRPM_ERR_OTHER;
 
     return DRPM_ERR_OK;
@@ -531,7 +531,7 @@ int readchunk_bzip2(struct decompstrm *strm)
 
     strm->comp_size += in_len;
 
-    if (strm->md5 != NULL && MD5_Update(strm->md5, in_buffer, in_len) != 1)
+    if (strm->md5 != NULL && EVP_DigestUpdate(strm->md5, in_buffer, in_len) != 1)
         return DRPM_ERR_OTHER;
 
     return DRPM_ERR_OK;
@@ -585,7 +585,7 @@ int readchunk_gzip(struct decompstrm *strm)
 
     strm->comp_size += in_len;
 
-    if (strm->md5 != NULL && MD5_Update(strm->md5, in_buffer, in_len) != 1)
+    if (strm->md5 != NULL && EVP_DigestUpdate(strm->md5, in_buffer, in_len) != 1)
         return DRPM_ERR_OTHER;
 
     return DRPM_ERR_OK;
@@ -645,7 +645,7 @@ int readchunk_lzma(struct decompstrm *strm)
 
     strm->comp_size += in_len;
 
-    if (strm->md5 != NULL && MD5_Update(strm->md5, in_buffer, in_len) != 1)
+    if (strm->md5 != NULL && EVP_DigestUpdate(strm->md5, in_buffer, in_len) != 1)
         return DRPM_ERR_OTHER;
 
     return DRPM_ERR_OK;
@@ -722,7 +722,7 @@ int readchunk_lzip(struct decompstrm *strm)
 
     strm->comp_size += in_len;
 
-    if (strm->md5 != NULL && MD5_Update(strm->md5, in_buffer, in_len) != 1)
+    if (strm->md5 != NULL && EVP_DigestUpdate(strm->md5, in_buffer, in_len) != 1)
         return DRPM_ERR_OTHER;
 
     return DRPM_ERR_OK;
@@ -772,7 +772,7 @@ int readchunk_zstd(struct decompstrm *strm)
 
     strm->comp_size += in_len;
 
-    if (strm->md5 != NULL && MD5_Update(strm->md5, in_buffer, in_len) != 1)
+    if (strm->md5 != NULL && EVP_DigestUpdate(strm->md5, in_buffer, in_len) != 1)
         return DRPM_ERR_OTHER;
 
     free(buffOut);

--- a/src/drpm_private.h
+++ b/src/drpm_private.h
@@ -30,6 +30,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <unistd.h>
+#include <openssl/evp.h>
 #include <openssl/md5.h>
 
 #define CHUNK_SIZE 1024
@@ -153,7 +154,7 @@ int compstrm_write_be64(struct compstrm *, uint64_t);
 //drpm_decompstrm.c
 int decompstrm_destroy(struct decompstrm **);
 int decompstrm_get_comp_size(struct decompstrm *, size_t *);
-int decompstrm_init(struct decompstrm **, int, unsigned short *, MD5_CTX *, const unsigned char *, size_t);
+int decompstrm_init(struct decompstrm **, int, unsigned short *, EVP_MD_CTX *, const unsigned char *, size_t);
 int decompstrm_read(struct decompstrm *, size_t, void *);
 int decompstrm_read_be32(struct decompstrm *, uint32_t *);
 int decompstrm_read_be64(struct decompstrm *, uint64_t *);
@@ -232,7 +233,7 @@ size_t sfxsrt_search(struct sfxsrt *, const unsigned char *, size_t,
 void create_be32(uint32_t, unsigned char *);
 void create_be64(uint64_t, unsigned char *);
 void dump_hex(char *, const unsigned char *, size_t);
-int md5_update_be32(MD5_CTX *, uint32_t);
+int md5_update_be32(EVP_MD_CTX *, uint32_t);
 uint16_t parse_be16(const unsigned char *);
 uint32_t parse_be32(const unsigned char *);
 uint64_t parse_be64(const unsigned char *);

--- a/src/drpm_utils.c
+++ b/src/drpm_utils.c
@@ -28,6 +28,7 @@
 #include <stdbool.h>
 #include <ctype.h>
 #include <sys/types.h>
+#include <openssl/evp.h>
 #include <openssl/md5.h>
 #include <openssl/sha.h>
 
@@ -83,13 +84,13 @@ void create_be64(uint64_t in, unsigned char out[8])
     out[7] = in;
 }
 
-int md5_update_be32(MD5_CTX *md5, uint32_t number)
+int md5_update_be32(EVP_MD_CTX *md5, uint32_t number)
 {
     unsigned char be32[4];
 
     create_be32(number, be32);
 
-    return MD5_Update(md5, be32, 4);
+    return EVP_DigestUpdate(md5, be32, 4);
 }
 
 /* Represents array of bytes pointed to by <source> of size <count>

--- a/src/drpm_write.c
+++ b/src/drpm_write.c
@@ -24,6 +24,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <fcntl.h>
+#include <openssl/evp.h>
 #include <openssl/md5.h>
 #include <rpm/rpmlib.h>
 
@@ -76,7 +77,7 @@ int write_deltarpm(struct deltarpm *delta)
     uint32_t ext_copies_size;
     unsigned char *header = NULL;
     uint32_t header_size;
-    MD5_CTX md5;
+    EVP_MD_CTX *md5 = NULL;
     unsigned char md5_digest[MD5_DIGEST_LENGTH] = {0};
     unsigned char *strm_data = NULL;
     size_t strm_data_len;
@@ -210,11 +211,16 @@ int write_deltarpm(struct deltarpm *delta)
         if ((error = rpm_fetch_header(delta->head.tgt_rpm, &header, &header_size)) != DRPM_ERR_OK)
             return error;
 
-        if (MD5_Init(&md5) != 1 ||
-            MD5_Update(&md5, header, header_size) != 1 ||
-            MD5_Update(&md5, strm_data, strm_data_len) != 1 ||
-            MD5_Final(md5_digest, &md5) != 1)
+        if ((md5 = EVP_MD_CTX_new(), md5 == NULL) ||
+            EVP_DigestInit_ex(md5, EVP_md5(), NULL) != 1 ||
+            EVP_DigestUpdate(md5, header, header_size) != 1 ||
+            EVP_DigestUpdate(md5, strm_data, strm_data_len) != 1 ||
+            EVP_DigestFinal_ex(md5, md5_digest, NULL) != 1) {
+            if (md5 != NULL)
+                EVP_MD_CTX_free(md5);
             return DRPM_ERR_OTHER;
+        }
+        EVP_MD_CTX_free(md5);
 
         if ((error = rpm_signature_empty(delta->head.tgt_rpm)) != DRPM_ERR_OK ||
             (error = rpm_signature_set_size(delta->head.tgt_rpm, header_size + strm_data_len)) != DRPM_ERR_OK ||


### PR DESCRIPTION
Hi,

Thanks for writing and maintaining libdrpm!

What do you think about this change (that I am about to add to the Debian package of libdrpm), prompted by the fact that OpenSSL 3.x declares the `MD5_*()` and `SHA256_*()` functions (among others) deprecated? The `EVP_Digest*()` ones have been around since at least OpenSSL 1.1.x, and they seem to do the job, although the allocation and clean-up of the context structure does add some code.

Thanks again, and keep up the great work!

G'luck,
Peter
