### PR TITLE
C99 compatibility fix for drpm_write.c

### DIFF
--- a/src/drpm_write.c
+++ b/src/drpm_write.c
@@ -23,6 +23,7 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include <string.h>
 #include <fcntl.h>
 #include <openssl/md5.h>
 #include <rpm/rpmlib.h>


### PR DESCRIPTION
Include <string.h> for various string functions.  This avoids implicit function declarations and resulting build failures with future compilers.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
