### PR TITLE
Initialize comp_data to NULL in drpm_apply()

### DIFF
--- a/src/drpm.c
+++ b/src/drpm.c
@@ -536,7 +536,7 @@ int drpm_apply(const char *old_rpm_name, const char *deltarpm_name, const char *
     uint32_t ext_copies_todo;
     size_t ext_copies_done = 0;
     size_t blk_id;
-    unsigned char *comp_data;
+    unsigned char *comp_data = NULL;
     size_t comp_data_len;
 
     if (deltarpm_name == NULL || new_rpm_name == NULL)


### PR DESCRIPTION
On exit, this function will free comp_data, so at least ensure it's initialized to NULL so free() does not SIGSEGV.

Fixes: #5