### PR TITLE
Add libcmocka suppresion file

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,7 +10,7 @@ foreach(name ${DRPM_TEST_RPM_PACKAGE_NAMES})
 endforeach()
 
 set(DRPM_TEST_ARGS_CMP_FILES -d ${CMAKE_CURRENT_BINARY_DIR})
-set(DRPM_TEST_ARGS_VALGRIND --error-exitcode=1 --read-var-info=yes --leak-check=full --show-leak-kinds=all --track-origins=yes --suppressions=${CMAKE_CURRENT_SOURCE_DIR}/lzma.supp)
+set(DRPM_TEST_ARGS_VALGRIND --error-exitcode=1 --read-var-info=yes --leak-check=full --show-leak-kinds=all --track-origins=yes --suppressions=${CMAKE_CURRENT_SOURCE_DIR}/lzma.supp --suppressions=${CMAKE_CURRENT_SOURCE_DIR}/cmocka.supp)
 
 set(CMAKE_BUILD_TYPE RelWithDebInfo)
 

--- a/test/cmocka.supp
+++ b/test/cmocka.supp
@@ -1,0 +1,17 @@
+{
+   <libcmocka2>
+   Memcheck:Cond
+   obj:/usr/lib/libcmocka.so.*
+   obj:/usr/lib/libcmocka.so.*
+   fun:_cmocka_run_group_tests
+   fun:main
+}
+{
+   <libcmocka3>
+   Memcheck:Cond
+   obj:/usr/lib/libcmocka.so.*
+   obj:/usr/lib/libcmocka.so.*
+   obj:/usr/lib/libcmocka.so.*
+   fun:_cmocka_run_group_tests
+   fun:main
+}


### PR DESCRIPTION
This blocks fedora release.

This is needed only on i686 architectures.
Interestingly when I compiled cmocka manually the problems disappeared.
I have verified the problems are not caused by drpm because they happen even if the tests are not doing anything.

The specific traces look like:
```
==1376228== Conditional jump or move depends on uninitialised value(s)
==1376228==    at 0x4743165: list_free (cmocka.c:660)
==1376228==    by 0x4743165: teardown_testing.isra.0 (cmocka.c:585)
==1376228==    by 0x4744D22: cmocka_run_one_test_or_fixture (cmocka.c:2973)
==1376228==    by 0x47454FB: cmocka_run_one_tests (cmocka.c:3056)
==1376228==    by 0x47454FB: _cmocka_run_group_tests (cmocka.c:3187)
==1376228==    by 0x804CA65: main (drpm_api_tests.c:1040)
==1376228==  Uninitialised value was created by a heap allocation
==1376228==    at 0x403E7AF: malloc (vg_replace_malloc.c:447)
==1376228==    by 0x4064B2D: ??? (in /usr/lib/libz.so.1.3.1.zlib-ng)
==1376228==    by 0x4064AC2: ??? (in /usr/lib/libz.so.1.3.1.zlib-ng)
==1376228==    by 0x40696A3: ??? (in /usr/lib/libz.so.1.3.1.zlib-ng)
==1376228==    by 0x8053D32: init_gzip (drpm_decompstrm.c:179)
==1376228==    by 0x8053FF0: decompstrm_init (drpm_decompstrm.c:297)
==1376228==    by 0x8058A8F: readdelta_rest (drpm_read.c:98)
==1376228==    by 0x80597FA: read_deltarpm (drpm_read.c:469)
==1376228==    by 0x804CBC9: drpm_read (drpm.c:74)
==1376228==    by 0x804B514: read_rpmonly_noaddblk (drpm_api_tests.c:646)
==1376228==    by 0x4744CEC: cmocka_run_one_test_or_fixture (cmocka.c:2948)
==1376228==    by 0x47454FB: cmocka_run_one_tests (cmocka.c:3056)
==1376228==    by 0x47454FB: _cmocka_run_group_tests (cmocka.c:3187)
==1376228==
```
or
```
==1376228== Conditional jump or move depends on uninitialised value(s)
==1376228==    at 0x4744B55: check_for_leftover_values_list (cmocka.c:900)
==1376228==    by 0x4744B55: fail_if_leftover_values.isra.0 (cmocka.c:567)
==1376228==    by 0x4744D05: cmocka_run_one_test_or_fixture (cmocka.c:2966)
==1376228==    by 0x47454FB: cmocka_run_one_tests (cmocka.c:3056)
==1376228==    by 0x47454FB: _cmocka_run_group_tests (cmocka.c:3187)
==1376228==    by 0x804CA65: main (drpm_api_tests.c:1040)
==1376228==  Uninitialised value was created by a heap allocation
==1376228==    at 0x403E7AF: malloc (vg_replace_malloc.c:447)
==1376228==    by 0x4064B2D: ??? (in /usr/lib/libz.so.1.3.1.zlib-ng)
==1376228==    by 0x4064AC2: ??? (in /usr/lib/libz.so.1.3.1.zlib-ng)
==1376228==    by 0x40696A3: ??? (in /usr/lib/libz.so.1.3.1.zlib-ng)
==1376228==    by 0x8053D32: init_gzip (drpm_decompstrm.c:179)
==1376228==    by 0x8053FF0: decompstrm_init (drpm_decompstrm.c:297)
==1376228==    by 0x8058A8F: readdelta_rest (drpm_read.c:98)
==1376228==    by 0x80597FA: read_deltarpm (drpm_read.c:469)
==1376228==    by 0x804CBC9: drpm_read (drpm.c:74)
==1376228==    by 0x804B514: read_rpmonly_noaddblk (drpm_api_tests.c:646)
==1376228==    by 0x4744CEC: cmocka_run_one_test_or_fixture (cmocka.c:2948)
==1376228==    by 0x47454FB: cmocka_run_one_tests (cmocka.c:3056)
==1376228==    by 0x47454FB: _cmocka_run_group_tests (cmocka.c:3187)
==1376228==
```

However this is only visible when the build is done with cmocka debug symbols without them it is only:
```
==1376687== Conditional jump or move depends on uninitialised value(s)
==1376687==    at 0x4743165: ??? (in /usr/lib/libcmocka.so.0.8.1)
==1376687==    by 0x4744D22: ??? (in /usr/lib/libcmocka.so.0.8.1)
==1376687==    by 0x47454FB: _cmocka_run_group_tests (in /usr/lib/libcmocka.so.0.8.1)
==1376687==    by 0x804CA65: main (drpm_api_tests.c:1040)
==1376687==  Uninitialised value was created by a heap allocation
==1376687==    at 0x403E7AF: malloc (vg_replace_malloc.c:447)
==1376687==    by 0x4064B2D: ??? (in /usr/lib/libz.so.1.3.1.zlib-ng)
==1376687==    by 0x4064AC2: ??? (in /usr/lib/libz.so.1.3.1.zlib-ng)
==1376687==    by 0x40696A3: ??? (in /usr/lib/libz.so.1.3.1.zlib-ng)
==1376687==    by 0x8053D32: init_gzip (drpm_decompstrm.c:179)
==1376687==    by 0x8053FF0: decompstrm_init (drpm_decompstrm.c:297)
==1376687==    by 0x8058A8F: readdelta_rest (drpm_read.c:98)
==1376687==    by 0x80597FA: read_deltarpm (drpm_read.c:469)
==1376687==    by 0x804CBC9: drpm_read (drpm.c:74)
==1376687==    by 0x804B514: read_rpmonly_noaddblk (drpm_api_tests.c:646)
==1376687==    by 0x4744CEC: ??? (in /usr/lib/libcmocka.so.0.8.1)
==1376687==    by 0x47454FB: _cmocka_run_group_tests (in /usr/lib/libcmocka.so.0.8.1)
==1376687==
```
Since by default the debug symbols are missing the suppresion file cannot use the specific function names because it wouldn't match.